### PR TITLE
Ensure ruby uses top-level WebSocket constant in client.rb. Provides em-websocket compatibility.

### DIFF
--- a/lib/websocket/eventmachine/client.rb
+++ b/lib/websocket/eventmachine/client.rb
@@ -53,7 +53,7 @@ module WebSocket
       # @private
       def post_init
         @state = :connecting
-        @handshake = WebSocket::Handshake::Client.new(@args)
+        @handshake = ::WebSocket::Handshake::Client.new(@args)
       end
 
       # Called by EventMachine after connecting.
@@ -67,11 +67,11 @@ module WebSocket
       private
 
       def incoming_frame
-        WebSocket::Frame::Incoming::Client
+        ::WebSocket::Frame::Incoming::Client
       end
 
       def outgoing_frame
-        WebSocket::Frame::Outgoing::Client
+        ::WebSocket::Frame::Outgoing::Client
       end
 
       public


### PR DESCRIPTION
This commit enables compatibility with the em-websocket server gem.

The em-websocket gem adds a WebSocket module under the EventMachine
namespace. The client.rb file references the WebSocket constant while
executing within the EventMachine namespace. Once em-websocket is
required, client.rb begins using the WebSocket module provided by
the em-websocket gem instead of the correct top-level constant that
it expects, resulting in undefined method exceptions.
